### PR TITLE
side column font color fixed to white

### DIFF
--- a/src/component/Overlay/Side/VisibilitySwitchOption/VisibilitySwitchOption.module.styl
+++ b/src/component/Overlay/Side/VisibilitySwitchOption/VisibilitySwitchOption.module.styl
@@ -37,6 +37,9 @@
 
   overflow auto
 
+  *
+    color #fff !important
+
   &::-webkit-scrollbar
     width 4px
     height 4px


### PR DESCRIPTION
close #2

黒背景白文字を強制する。
 
ライトモードに合わせて白背景黒文字にしたかったが、youtubeサイト内のcss変数にalpha値を付加する必要が出てきて無理だった。
jsでparseしてalpha付加してrgbaテキストにしてcssに返すの、ちょっとめんどいので。

それと、Theater mode はヘッダーから動画までの範囲がdark-theme固定っぽかったので、一応デフォルト表示準拠ではある。
逆にライトモード対応させたくはある。めんどいが。