### PR TITLE
:bug: Supprot mobile chat element placed within `#primary`

### DIFF
--- a/src/component/Overlay/Side/index.tsx
+++ b/src/component/Overlay/Side/index.tsx
@@ -88,7 +88,7 @@ export const Side = (
 
   const nav = {
     description: "#columns #primary ytd-watch-metadata",
-    chat: "#columns #secondary #chat-container",
+    chat: "#columns #chat-container",
     comments: "#columns #primary ytd-comments#comments",
     playlist: "#columns #secondary ytd-playlist-panel-renderer",
     related: "#columns #secondary #related",


### PR DESCRIPTION
close #3

生放送チャット欄のelementを `#columns #secondary #chat-container` で指定していたが、画面幅が小さい場合は `#primary` に配置されるようで、取得できていなかった。